### PR TITLE
Fix telephone number will miss 0 in the front

### DIFF
--- a/swift-demo/Hyphenate Messenger/LoginVerificationViewController.swift
+++ b/swift-demo/Hyphenate Messenger/LoginVerificationViewController.swift
@@ -67,7 +67,7 @@ class LoginVerificationViewController: UIViewController {
         let area = num / 10000000
         let mid = (num - area * 10000000) / 10000
         let last = num - area * 10000000 - mid * 10000
-        return "+1 (\(area)) \(mid) \(last)"
+        return String(format: "+1 (%03d) %03d %04d", area, mid, last)
     }
     
     // MARK: - Timer


### PR DESCRIPTION
As using integer calculation, the 0 will be omitted in the string,
forex, 6475120300 will become 647 512 300