### PR TITLE
Added support for loading the profile at login

### DIFF
--- a/swift-demo/Hyphenate Messenger/AppDelegate.swift
+++ b/swift-demo/Hyphenate Messenger/AppDelegate.swift
@@ -294,6 +294,10 @@ extension AppDelegate {
         let uid = "+1" + EMClient.shared().currentUsername!
         AppConfig.sharedInstance.performUserSpecificConfigFor(uid)
         
+        if AppConfig.sharedInstance.profileNeedsUpdate {
+            AppConfig.sharedInstance.getUserProfileAtLogin(uid)
+        }
+        
         self.mainViewController = MainViewController()
         HyphenateMessengerHelper.sharedInstance.mainVC = mainViewController
         HyphenateMessengerHelper.sharedInstance.loadConversationFromDB()

--- a/swift-demo/Hyphenate Messenger/HyphenateMessengerHelper.swift
+++ b/swift-demo/Hyphenate Messenger/HyphenateMessengerHelper.swift
@@ -639,7 +639,8 @@ class HyphenateMessengerHelper: NSObject, EMClientDelegate, EMChatManagerDelegat
                 print("Error!!! Failed to logout properly!")
                 NotificationCenter.default.post(name: Notification.Name(rawValue: "KNotification_logout"), object: nil)
             }
-            let loginController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "loginScene")
+            
+            let loginController = UIStoryboard(name: "Authentication", bundle: nil).instantiateViewController(withIdentifier: "loginScene")
             UIApplication.shared.keyWindow?.rootViewController = loginController
         }
     }

--- a/swift-demo/Hyphenate Messenger/MainViewController.swift
+++ b/swift-demo/Hyphenate Messenger/MainViewController.swift
@@ -26,6 +26,8 @@ class MainViewController: UITabBarController {
         let settingsRootViewController:UINavigationController = UINavigationController(rootViewController: settingsViewController)
         settingsRootViewController.navigationBar.isTranslucent = false
         settingsRootViewController.title = "Settings"
+        // reload table when profile fetch completes
+        AppConfig.sharedInstance.profileDelegate = settingsViewController
 
         self.setViewControllers([homeViewController, historyRootViewController, shopRootViewController, settingsRootViewController], animated: true)
         

--- a/swift-demo/Hyphenate Messenger/ProfileSetting/EmailViewController.swift
+++ b/swift-demo/Hyphenate Messenger/ProfileSetting/EmailViewController.swift
@@ -20,7 +20,7 @@ class EmailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // get email from DB
-        self.EmailText.text = UserDefaults.standard.string(forKey: "email")
+        self.EmailText.text = UserDefaults.standard.string(forKey: DataBaseKeys.profileEmailKey)
         EmailText.becomeFirstResponder()
         EmailText.clearButtonMode = .always
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(_:))))
@@ -43,15 +43,15 @@ class EmailViewController: UIViewController {
         
         // Retrive Email from firebase
         // Store data to UserDefaults
-        self.ref.child("users").child(uid).child("email").observeSingleEvent(of: .value, with: { (snapshot) in
+        self.ref.child("users").child(uid).child(DataBaseKeys.profileEmailKey).observeSingleEvent(of: .value, with: { (snapshot) in
             if snapshot.exists(){
                 let val = snapshot.value as? String
                 if (val! != ""){
-                    UserDefaults.standard.set(val, forKey: "email")
+                    UserDefaults.standard.set(val, forKey: DataBaseKeys.profileEmailKey)
                 }
                 else{
                     print("Username is an empty string!")
-                    UserDefaults.standard.set("Unknown", forKey: "email")
+                    UserDefaults.standard.set("Unknown", forKey: DataBaseKeys.profileEmailKey)
                 }
             }
             MBProgressHUD.hide(for: self.view, animated: true)

--- a/swift-demo/Hyphenate Messenger/ProfileSetting/GradeViewController.swift
+++ b/swift-demo/Hyphenate Messenger/ProfileSetting/GradeViewController.swift
@@ -40,9 +40,6 @@ class GradeViewController: UIViewController,UIPickerViewDelegate, UIPickerViewDa
     //MARK: - Outlets
     @IBOutlet weak var gradePickerView: UIPickerView!
     
-
-    
-    
     //MARK: - Interactions
     @IBAction func dismissView(_ sender: UIBarButtonItem) {
         MBProgressHUD.showAdded(to: self.view, animated: true)
@@ -53,13 +50,13 @@ class GradeViewController: UIViewController,UIPickerViewDelegate, UIPickerViewDa
         // Retrive Grade from DB
         // Store data to UserDefaults
         var updatedGrade:String?
-        self.ref.child("users").child(self.uid).child("grade").observeSingleEvent(of: .value, with: {
+        self.ref.child("users").child(self.uid).child(DataBaseKeys.profileGradeKey).observeSingleEvent(of: .value, with: {
             (snapshot) in
             updatedGrade = snapshot.value as? String
             if updatedGrade == nil{
-                UserDefaults.standard.set("Unknown", forKey: "grade")
+                UserDefaults.standard.set("Unknown", forKey: DataBaseKeys.profileGradeKey)
             } else {
-                UserDefaults.standard.set(updatedGrade, forKey: "grade")
+                UserDefaults.standard.set(updatedGrade, forKey: DataBaseKeys.profileGradeKey)
             }
             MBProgressHUD.hide(for: self.view, animated: true)
             self.navigationController?.popViewController(animated: true)

--- a/swift-demo/Hyphenate Messenger/ProfileSetting/MyProfileViewControllerTableViewController.swift
+++ b/swift-demo/Hyphenate Messenger/ProfileSetting/MyProfileViewControllerTableViewController.swift
@@ -1,17 +1,9 @@
-//
-//  MyProfileViewControllerTableViewController.swift
-//  ProfileSetting
-//
-//  Created by Yi Jerry on 2017-09-23.
-//  Copyright © 2017 Yi Jerry. All rights reserved.
-//
-
 import UIKit
 import Firebase
 import FirebaseDatabase
 
 
-class MyProfileViewControllerTableViewController: UITableViewController{
+class MyProfileViewControllerTableViewController: UITableViewController {
     
     // MARK: - Properties
     var ref = Database.database().reference()
@@ -117,9 +109,9 @@ class MyProfileViewControllerTableViewController: UITableViewController{
         let cell = tableView.dequeueReusableCell(withIdentifier: "profileHeaderCell") as! profileHeaderTableViewCell
         switch section {
         case 0:
-            cell.headerLabel.text = "PROFILE"
+            cell.headerLabel.text = "Profile"
         case 1:
-            cell.headerLabel.text = "INFORMATION"
+            cell.headerLabel.text = "Information"
         default:
             break
         }
@@ -128,7 +120,7 @@ class MyProfileViewControllerTableViewController: UITableViewController{
     }
     
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 40
+        return 35
     }
     
     // change Height of Profile Picture Cell
@@ -139,6 +131,7 @@ class MyProfileViewControllerTableViewController: UITableViewController{
         }
         return 40
     }
+    
     /*
     // MARK: - Navigation
 

--- a/swift-demo/Hyphenate Messenger/ProfileSetting/NameViewController.swift
+++ b/swift-demo/Hyphenate Messenger/ProfileSetting/NameViewController.swift
@@ -20,7 +20,7 @@ class NameViewController: UIViewController {
     // MARK: - View Did Load
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.nameChangTextView.text = UserDefaults.standard.string(forKey: "userName")
+        self.nameChangTextView.text = UserDefaults.standard.string(forKey: DataBaseKeys.profileUserNameKey)
         nameChangTextView.becomeFirstResponder()
         nameChangTextView.clearButtonMode = .always
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(_:))))
@@ -43,10 +43,10 @@ class NameViewController: UIViewController {
             if snapshot.exists(){
                 let val = snapshot.value as? String
                 if (val! != ""){
-                    UserDefaults.standard.set(val, forKey: "userName")
+                    UserDefaults.standard.set(val, forKey: DataBaseKeys.profileUserNameKey)
                 }
                 else{
-                    UserDefaults.standard.set("Unknown", forKey: "userName")
+                    UserDefaults.standard.set("Unknown", forKey: DataBaseKeys.profileUserNameKey)
                 }
             }
              MBProgressHUD.hide(for: self.view, animated: true)

--- a/swift-demo/Hyphenate Messenger/ProfileSetting/ProfileMain.storyboard
+++ b/swift-demo/Hyphenate Messenger/ProfileSetting/ProfileMain.storyboard
@@ -47,7 +47,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OWk-dK-PNm" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="790" y="884"/>
+            <point key="canvasLocation" x="1005" y="914"/>
         </scene>
         <!--Photo-->
         <scene sceneID="VAl-LF-bax">
@@ -89,7 +89,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="80d-dm-ACy" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="975" y="-618"/>
+            <point key="canvasLocation" x="2252" y="-697"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="Bsk-1U-7WF">
@@ -151,7 +151,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="T87-Xj-0ge" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1708" y="741"/>
+            <point key="canvasLocation" x="2252" y="733"/>
         </scene>
         <!--Name-->
         <scene sceneID="B6S-ku-0mW">
@@ -212,23 +212,23 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="profileHeaderCell" id="XKD-S7-wqk" customClass="profileHeaderTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="320" height="40"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="profileHeaderCell" rowHeight="35" id="XKD-S7-wqk" customClass="profileHeaderTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="55.5" width="320" height="35"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="XKD-S7-wqk" id="JNF-Jo-Ndj">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="34.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PROFILE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sg0-pP-rae">
-                                            <rect key="frame" x="18" y="8" width="294" height="23.5"/>
-                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="10"/>
-                                            <color key="textColor" red="0.61629542820000005" green="0.63843911919999996" blue="0.62872373469999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="8" y="8" width="304" height="18.5"/>
+                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                            <color key="textColor" red="0.40539323255876064" green="0.4183636443869112" blue="0.41437849641584157" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="sg0-pP-rae" firstAttribute="top" secondItem="JNF-Jo-Ndj" secondAttribute="topMargin" id="Pcb-RQ-g3h"/>
-                                        <constraint firstItem="sg0-pP-rae" firstAttribute="leading" secondItem="JNF-Jo-Ndj" secondAttribute="leadingMargin" constant="10" id="QNu-iQ-UDJ"/>
+                                        <constraint firstItem="sg0-pP-rae" firstAttribute="leading" secondItem="JNF-Jo-Ndj" secondAttribute="leadingMargin" id="QNu-iQ-UDJ"/>
                                         <constraint firstItem="sg0-pP-rae" firstAttribute="trailing" secondItem="JNF-Jo-Ndj" secondAttribute="trailingMargin" id="ojc-Lx-zp9"/>
                                         <constraint firstItem="sg0-pP-rae" firstAttribute="bottom" secondItem="JNF-Jo-Ndj" secondAttribute="bottomMargin" id="rCD-Ef-VGE"/>
                                     </constraints>
@@ -238,7 +238,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="profilePictureCell" rowHeight="91" id="Fr9-Rt-QWm" customClass="profilePictureTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="95.5" width="320" height="91"/>
+                                <rect key="frame" x="0.0" y="90.5" width="320" height="91"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Fr9-Rt-QWm" id="HDt-B9-sQS">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="90.5"/>
@@ -285,7 +285,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="nameCell" id="N6p-AA-fin" customClass="nameTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="186.5" width="320" height="40"/>
+                                <rect key="frame" x="0.0" y="181.5" width="320" height="40"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="N6p-AA-fin" id="aBq-fZ-bei">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>
@@ -327,24 +327,24 @@
                                     <segue destination="Ra1-J8-NcZ" kind="show" id="jFg-D3-9Iq"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="informationHeaderCell" id="HOr-Og-mrE" customClass="informationHeaderTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="226.5" width="320" height="40"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="informationHeaderCell" rowHeight="35" id="HOr-Og-mrE" customClass="informationHeaderTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="221.5" width="320" height="35"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="HOr-Og-mrE" id="uxK-K8-1Wl">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="34.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="INFORMATION" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jx5-G3-5BJ">
-                                            <rect key="frame" x="18" y="8" width="294" height="23.5"/>
-                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="10"/>
-                                            <color key="textColor" red="0.61629542820000005" green="0.63843911919999996" blue="0.62872373469999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="8" y="8" width="304" height="18.5"/>
+                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                            <color key="textColor" red="0.40539323259999999" green="0.41836364440000001" blue="0.41437849640000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="Jx5-G3-5BJ" firstAttribute="bottom" secondItem="uxK-K8-1Wl" secondAttribute="bottomMargin" id="1vV-yv-nSb"/>
                                         <constraint firstItem="Jx5-G3-5BJ" firstAttribute="top" secondItem="uxK-K8-1Wl" secondAttribute="topMargin" id="TQK-dj-C0e"/>
-                                        <constraint firstItem="Jx5-G3-5BJ" firstAttribute="leading" secondItem="uxK-K8-1Wl" secondAttribute="leadingMargin" constant="10" id="d3y-V7-Fbf"/>
+                                        <constraint firstItem="Jx5-G3-5BJ" firstAttribute="leading" secondItem="uxK-K8-1Wl" secondAttribute="leadingMargin" id="d3y-V7-Fbf"/>
                                         <constraint firstItem="Jx5-G3-5BJ" firstAttribute="trailing" secondItem="uxK-K8-1Wl" secondAttribute="trailingMargin" id="fpL-5l-VpT"/>
                                     </constraints>
                                 </tableViewCellContentView>
@@ -353,7 +353,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="gradeCell" id="MY3-Hs-Zn3" customClass="gradeTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="266.5" width="320" height="40"/>
+                                <rect key="frame" x="0.0" y="256.5" width="320" height="40"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MY3-Hs-Zn3" id="5Gn-JY-6BP">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>
@@ -396,7 +396,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="emailCell" id="Lcv-1I-qEq" customClass="emailTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="306.5" width="320" height="40"/>
+                                <rect key="frame" x="0.0" y="296.5" width="320" height="40"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Lcv-1I-qEq" id="lIY-il-FFv">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>

--- a/swift-demo/Hyphenate Messenger/ProfileSetting/ProfileSettingViewController.swift
+++ b/swift-demo/Hyphenate Messenger/ProfileSetting/ProfileSettingViewController.swift
@@ -28,7 +28,7 @@ class ProfileSettingViewController: UIViewController, UIImagePickerControllerDel
         imageView.layer.cornerRadius = imageView.frame.size.width/1.8
         imageView.clipsToBounds = true
 
-        if let data = UserDefaults.standard.data(forKey: "profilePicture"){
+        if let data = UserDefaults.standard.data(forKey: DataBaseKeys.profilePhotoKey){
             let imageUIImage: UIImage = UIImage(data: data)!
             imageView.image = imageUIImage
         }else{
@@ -75,7 +75,7 @@ class ProfileSettingViewController: UIViewController, UIImagePickerControllerDel
                 print("Going to download from DB")
                 // Retrive Profile Picture from DB
                 // Store data to UserDefaults
-                self.ref.child("users").child(self.uid).child("profilepicURL").observeSingleEvent(of: .value, with: {(snapshot) in
+            self.ref.child("users").child(self.uid).child("profilepicURL").observeSingleEvent(of: .value, with: {(snapshot) in
                     
                     print("downloaded from DB")
                     var imageBuffer: UIImage
@@ -86,13 +86,13 @@ class ProfileSettingViewController: UIViewController, UIImagePickerControllerDel
                         if (val == nil){
                             imageBuffer = UIImage(named: "placeholder")!
                             let imgData = UIImageJPEGRepresentation(imageBuffer, 1)
-                            UserDefaults.standard.set(imgData, forKey: "profilePicture")
+                            UserDefaults.standard.set(imgData, forKey: DataBaseKeys.profilePhotoKey)
                         }
                         else{
                             print("Recieve Non-null image")
                             print("Setting UsersDefault")
                             let imgData = UIImageJPEGRepresentation(self.imageView.image!, 1)
-                            UserDefaults.standard.set(imgData, forKey: "profilePicture")
+                            UserDefaults.standard.set(imgData, forKey: DataBaseKeys.profilePhotoKey)
                         }
                     } else {
                         print("snapShot DNE error")

--- a/swift-demo/Hyphenate Messenger/ProfileSetting/profileHeaderTableViewCell.swift
+++ b/swift-demo/Hyphenate Messenger/ProfileSetting/profileHeaderTableViewCell.swift
@@ -1,11 +1,3 @@
-//
-//  profileHeaderTableViewCell.swift
-//  ProfileSetting
-//
-//  Created by Yi Jerry on 2017-09-23.
-//  Copyright © 2017 Yi Jerry. All rights reserved.
-//
-
 import UIKit
 
 class profileHeaderTableViewCell: UITableViewCell {

--- a/swift-demo/Hyphenate Messenger/SettingProfileTableViewCell.swift
+++ b/swift-demo/Hyphenate Messenger/SettingProfileTableViewCell.swift
@@ -4,16 +4,14 @@ import UIKit
 class SettingProfileTableViewCell: UITableViewCell {
     
     @IBOutlet weak var senderLabel: UILabel!
-    @IBOutlet weak var timeLabel: UILabel!
     @IBOutlet weak var lastMessageLabel: UILabel!
     @IBOutlet weak var senderImageView: UIImageView!
     //    @IBOutlet weak var badgeView: M13BadgeView!
     
-    @IBOutlet weak var badgeView: M13BadgeView!
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
-        senderImageView.layer.cornerRadius = 25.0
+        senderImageView.layer.cornerRadius = 10.0
         senderImageView.clipsToBounds = true
     }
     

--- a/swift-demo/Hyphenate Messenger/SettingProfileTableViewCell.xib
+++ b/swift-demo/Hyphenate Messenger/SettingProfileTableViewCell.xib
@@ -1,88 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="settingProfileCell" rowHeight="99" id="NmH-xZ-dd3" customClass="SettingProfileTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="337" height="99"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="settingProfileCell" rowHeight="90" id="NmH-xZ-dd3" customClass="SettingProfileTableViewCell" customModule="Hyphenate_Messenger" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="337" height="90"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NmH-xZ-dd3" id="jwt-th-fZv">
-                <rect key="frame" x="0.0" y="0.0" width="337" height="98.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="337" height="89.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="VTW-na-8pl">
-                        <rect key="frame" x="15" y="14.5" width="70" height="70"/>
+                        <rect key="frame" x="8" y="10" width="70" height="70"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="70" id="9Vg-Zo-ZsM"/>
                             <constraint firstAttribute="width" constant="70" id="HD0-mT-Dme"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lkA-uK-713">
-                        <rect key="frame" x="98" y="20" width="119" height="21"/>
+                        <rect key="frame" x="91" y="10" width="212" height="27.5"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="21" id="EMr-nt-hex"/>
+                            <constraint firstAttribute="height" constant="27.5" id="Rsm-4a-svl"/>
+                            <constraint firstAttribute="width" constant="212" id="V9W-bi-K1X"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="1 hour ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6le-yu-fmG">
-                        <rect key="frame" x="238" y="20.5" width="85" height="20.5"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="85" id="0wO-YH-zMg"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bu8-of-i8F" customClass="M13BadgeView">
-                        <rect key="frame" x="66" y="8" width="24" height="24"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="24" id="mvi-WW-ejs"/>
-                            <constraint firstAttribute="width" constant="24" id="sop-2i-sIM"/>
-                        </constraints>
-                    </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="96V-zl-Q50">
-                        <rect key="frame" x="98" y="49" width="231" height="21"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="21" id="Yd3-Sf-Vpd"/>
-                        </constraints>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="96V-zl-Q50">
+                        <rect key="frame" x="91" y="51.5" width="212" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailingMargin" secondItem="96V-zl-Q50" secondAttribute="trailing" constant="6" id="5Hj-SZ-JYB"/>
-                    <constraint firstItem="96V-zl-Q50" firstAttribute="top" secondItem="6le-yu-fmG" secondAttribute="bottom" constant="8" symbolic="YES" id="FOg-07-qg2"/>
-                    <constraint firstItem="bu8-of-i8F" firstAttribute="top" secondItem="jwt-th-fZv" secondAttribute="topMargin" constant="8" id="Fld-h4-WQG"/>
-                    <constraint firstItem="lkA-uK-713" firstAttribute="top" secondItem="jwt-th-fZv" secondAttribute="topMargin" constant="12" id="HOd-Jg-jE9"/>
-                    <constraint firstItem="6le-yu-fmG" firstAttribute="trailing" secondItem="96V-zl-Q50" secondAttribute="trailing" id="NH2-3L-oXt"/>
-                    <constraint firstItem="6le-yu-fmG" firstAttribute="leading" secondItem="lkA-uK-713" secondAttribute="trailing" constant="21" id="Y8r-rQ-Zqy"/>
-                    <constraint firstItem="VTW-na-8pl" firstAttribute="leading" secondItem="jwt-th-fZv" secondAttribute="leadingMargin" constant="7" id="ZrL-Mm-bo1"/>
-                    <constraint firstItem="lkA-uK-713" firstAttribute="leading" secondItem="bu8-of-i8F" secondAttribute="trailing" constant="6" id="cgC-Gn-kmr"/>
-                    <constraint firstItem="6le-yu-fmG" firstAttribute="baseline" secondItem="lkA-uK-713" secondAttribute="baseline" id="ecH-yA-l4G"/>
+                    <constraint firstItem="96V-zl-Q50" firstAttribute="width" secondItem="lkA-uK-713" secondAttribute="width" id="1ob-Sk-Ipx"/>
+                    <constraint firstItem="96V-zl-Q50" firstAttribute="top" secondItem="lkA-uK-713" secondAttribute="bottom" constant="14" id="Rta-N3-BXw"/>
+                    <constraint firstItem="lkA-uK-713" firstAttribute="top" secondItem="VTW-na-8pl" secondAttribute="top" id="UgP-iz-BSU"/>
+                    <constraint firstItem="VTW-na-8pl" firstAttribute="leading" secondItem="jwt-th-fZv" secondAttribute="leadingMargin" id="ZrL-Mm-bo1"/>
                     <constraint firstItem="VTW-na-8pl" firstAttribute="centerY" secondItem="jwt-th-fZv" secondAttribute="centerY" id="gN1-Ax-waw"/>
+                    <constraint firstItem="96V-zl-Q50" firstAttribute="leading" secondItem="lkA-uK-713" secondAttribute="leading" id="gcV-J3-MmM"/>
                     <constraint firstItem="lkA-uK-713" firstAttribute="leading" secondItem="VTW-na-8pl" secondAttribute="trailing" constant="13" id="nCS-nI-yII"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="badgeView" destination="bu8-of-i8F" id="4kW-t9-Ycg"/>
                 <outlet property="lastMessageLabel" destination="96V-zl-Q50" id="jck-C7-cJe"/>
                 <outlet property="senderImageView" destination="VTW-na-8pl" id="WKp-b0-hic"/>
                 <outlet property="senderLabel" destination="lkA-uK-713" id="eQb-ZM-hOU"/>
-                <outlet property="timeLabel" destination="6le-yu-fmG" id="jZg-S3-0gh"/>
             </connections>
-            <point key="canvasLocation" x="544.5" y="415.5"/>
+            <point key="canvasLocation" x="544.5" y="411"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/swift-demo/Hyphenate Messenger/SettingsTableViewController.swift
+++ b/swift-demo/Hyphenate Messenger/SettingsTableViewController.swift
@@ -6,7 +6,7 @@ import Firebase
 import FirebaseDatabase
 
 
-class SettingsTableViewController: UITableViewController, MFMailComposeViewControllerDelegate{
+class SettingsTableViewController: UITableViewController, MFMailComposeViewControllerDelegate, ConfigDelegate {
     
     var ref: DatabaseReference!
     var uid = "+1" + EMClient.shared().currentUsername!
@@ -59,16 +59,14 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
             // My Profile TODO: don't use conversation table view cell, better make a new one
             let cell:SettingProfileTableViewCell = tableView.dequeueReusableCell(withIdentifier: "settingProfileCell", for: indexPath) as! SettingProfileTableViewCell
             cell.senderLabel.text = ""
-            cell.badgeView.isHidden = true
-            cell.timeLabel.isHidden = true
             cell.lastMessageLabel.isHidden = true
             cell.senderImageView.contentMode = UIViewContentMode.scaleAspectFill
             
             // username
-            cell.senderLabel.text = UserDefaults.standard.string(forKey: "userName")
+            cell.senderLabel.text = UserDefaults.standard.string(forKey: DataBaseKeys.profileUserNameKey)
             // profile picture
             let imageUIImage: UIImage
-            if let data = UserDefaults.standard.data(forKey: "profilePicture"){
+            if let data = UserDefaults.standard.data(forKey:  DataBaseKeys.profilePhotoKey){
                 imageUIImage = UIImage(data: data)!
             }else{
                 imageUIImage = UIImage(named:"placeholder")!
@@ -146,7 +144,7 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
     // change Height of Profile Picture Cell
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if (indexPath.section == 0 && indexPath.row == 0){
-            return 100
+            return 90
         } else {
             return UITableViewAutomaticDimension
         }
@@ -172,6 +170,9 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
     }
     
     func logoutAction() {
+        // config the usser logout
+        AppConfig.sharedInstance.processUserLogout()
+        
         // delete all conversation history
         let chatManager = EMClient.shared().chatManager
         if let allConversations = EMClient.shared().chatManager.getAllConversations() as? [EMConversation] {
@@ -235,6 +236,11 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
         }
         // Dismiss mail view controller and back to setting page
         self.dismiss(animated:true, completion: nil)
+    }
+    
+    // MARK: - finish loading profile data
+    func didFetchConfigTypeProfile() {
+        tableView.reloadData()
     }
 }
 

--- a/swift-demo/Hyphenate Messenger/ShopTableVIewController.swift
+++ b/swift-demo/Hyphenate Messenger/ShopTableVIewController.swift
@@ -406,7 +406,10 @@ class ShopTableViewController: UITableViewController, STPAddCardViewControllerDe
                     // send alert
                     let title = "Payment successful"
                     let chargedAmount: Double = (self.numDiscountAvailable > 0) ? (Double(amount) * self.discountRate).rounded(.up) : Double(amount)
-                    let message = "You have purchased \(self.product) minutes for $\(chargedAmount/100)"
+                    
+                    let packageIdx = self.prices.index(of: amount) ?? 0
+                    let minutesPurchased = self.productMinutes[packageIdx]
+                    let message = "You have purchased \(minutesPurchased) minutes for $\(chargedAmount/100)"
                     
                     let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: "Ok", style: .cancel, handler: {(action) in
@@ -440,7 +443,6 @@ class ShopTableViewController: UITableViewController, STPAddCardViewControllerDe
         if indexPath.row == productMinutes.count{
             updateCard()
         }
-        
     }
     
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
The loading will start if the profileNeedsUpdate flag is set. This flag is set when
1. First launch the app
2. A user logs out

When user logs out, it also resets the profile value to defaults once.

The settingTVC is made to be the config.swift's delegate, so that when the profile data
comes back from Firebase, settingTVC is notified to reload data.

Modified the cells:
1. Setting profile table view cell: shrunk the cell height, changed constrint and text size
	removed some useless labels
2. Header view cell, changed size and font size, in MyprofileVCTVC

In shopTVC, fixed that the alertview won't display how many minutes user purchased

For Email/Grade/Name/ProfileSetting VC, changed database strings to constants defined,

Fixed possible crash due to force logout, which looks for main.storyboard(removed way earlier)