### PR TITLE
Fix: hit purchase and shop not appear

### DIFF
--- a/swift-demo/EaseUI/EMUIKit/3rdparty/MBProgressHUD/MBProgressHUD.m
+++ b/swift-demo/EaseUI/EMUIKit/3rdparty/MBProgressHUD/MBProgressHUD.m
@@ -453,6 +453,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	label.textColor = [UIColor whiteColor];
 	label.font = self.labelFont;
 	label.text = self.labelText;
+    label.numberOfLines = 2;
 	[self addSubview:label];
 	
 	detailsLabel = [[UILabel alloc] initWithFrame:self.bounds];

--- a/swift-demo/Hyphenate Messenger/HistoryTableViewController.swift
+++ b/swift-demo/Hyphenate Messenger/HistoryTableViewController.swift
@@ -24,8 +24,6 @@ open class HistoryTableViewController: UITableViewController, EMChatManagerDeleg
         newConversationButton.setBackgroundImage(image, for: UIControlState())
         newConversationButton.addTarget(self, action: #selector(ConversationsTableViewController.composeConversationAction), for: .touchUpInside)
         newConversationButton.showsTouchWhenHighlighted = true
-        let rightButtonItem = UIBarButtonItem(customView: newConversationButton)
-        self.tabBarController?.navigationItem.rightBarButtonItem = rightButtonItem
         
         self.tableView.register(UINib(nibName: "ConversationTableViewCell", bundle: nil), forCellReuseIdentifier: "Cell")
         self.tableView.separatorStyle = UITableViewCellSeparatorStyle.singleLine

--- a/swift-demo/Hyphenate Messenger/ShopTableVIewController.swift
+++ b/swift-demo/Hyphenate Messenger/ShopTableVIewController.swift
@@ -334,7 +334,7 @@ class ShopTableViewController: UITableViewController, STPAddCardViewControllerDe
         print("pay button clicked for amount: \(amount)")
         print(uid)
         
-        showHud(in: view, hint: "Purchasing")
+        showHud(in: view, hint: "Purchasing\nPlease do not leave the app")
         chargeUsingCustomerId(amount)
     }
     

--- a/swift-demo/Hyphenate Messenger/SummaryVC.swift
+++ b/swift-demo/Hyphenate Messenger/SummaryVC.swift
@@ -149,6 +149,23 @@ class SummaryVC: UIViewController, UITextViewDelegate, TutorConnectedDelegate, S
     //flag variable monitors which screen we are on. States: -1 = not set, 0 = tutor connecting screen, 1 = tutor connected screen
     var flag = -1
     
+    func presentShopView() {
+        // present modally the shop VC for purchasing minutes
+        let shopViewController = ShopTableViewController()
+        shopViewController.delegate = self
+        
+        let shopNavVC = UINavigationController(rootViewController: shopViewController)
+        shopNavVC.navigationBar.isTranslucent = false
+        shopNavVC.navigationBar.topItem?.title = "Shop"
+        
+        // dismissShop is defined in ShopTableViewController, just to dissmiss modal present
+        shopNavVC.navigationBar.topItem?.leftBarButtonItem = UIBarButtonItem(title: "Cancel", style: .plain, target: shopViewController, action: Selector(("dismissShop")))
+        shopNavVC.navigationBar.topItem?.leftBarButtonItem?.tintColor = UIColor(hex: "2EA2DC")
+        
+        shopViewController.isPurchasingBeforeReqeusting = true
+        self.present(shopNavVC, animated: true, completion: nil)
+    }
+    
     func requestHelpPressed(button: UIButton) {
         
         let time = Date().timeIntervalSince1970
@@ -157,21 +174,7 @@ class SummaryVC: UIViewController, UITextViewDelegate, TutorConnectedDelegate, S
                 "Your balance is less than \(self.threshold) mins. Your session will terminate when your balance is 0 ", preferredStyle: UIAlertControllerStyle.alert)
             
             alertController.addAction(UIAlertAction(title: "Purchase minutes", style: UIAlertActionStyle.default, handler: { _ in
-                // present modally the shop VC for purchasing minutes
-                let shopViewController = ShopTableViewController()
-                shopViewController.delegate = self
-                
-                let shopNavVC = UINavigationController(rootViewController: shopViewController)
-                shopNavVC.navigationBar.isTranslucent = false
-                shopNavVC.navigationBar.topItem?.title = "Shop"
-                
-                // dismissShop is defined in ShopTableViewController, just to dissmiss modal present
-                shopNavVC.navigationBar.topItem?.leftBarButtonItem = UIBarButtonItem(title: "Cancel", style: .plain, target: shopViewController, action: Selector(("dismissShop")))
-                shopNavVC.navigationBar.topItem?.leftBarButtonItem?.tintColor = UIColor(hex: "2EA2DC")
-                
-                shopViewController.isPurchasingBeforeReqeusting = true
-                self.present(shopNavVC, animated: true, completion: nil)
-                // self.dismiss(animated: true, completion: nil)
+                self.presentShopView()
             }))
             
             alertController.addAction(UIAlertAction(title: "Continue", style: .destructive, handler: {_ in
@@ -184,7 +187,7 @@ class SummaryVC: UIViewController, UITextViewDelegate, TutorConnectedDelegate, S
                 "Your balance is 0", preferredStyle: UIAlertControllerStyle.alert)
             
             alertController.addAction(UIAlertAction(title: "Purchase minutes", style: UIAlertActionStyle.default, handler: { _ in
-                self.dismiss(animated: true, completion: nil)
+                self.presentShopView()
             }))
              present(alertController, animated: true, completion: nil)
         } else {


### PR DESCRIPTION
When user hit purchase in the summaryVC, the shopVC should present. This
results from the incomplete code change when introducing the presenting VC
feature.

Also, enlarged the ProgressHUD's line to 2 to accommodate longer multilined
hint message