### PR TITLE
Added support for 3-part app versions

### DIFF
--- a/swift-demo/Hyphenate Messenger/Info.plist
+++ b/swift-demo/Hyphenate Messenger/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Added string extension to get the 3-part app version.
The version is compared based on order: major->minor->maintain
meaning that if required version is 1.1.12 and current version is 1.2.5,
the difference in maintain number will be ignored as the minor number
2 is larger than the required 1